### PR TITLE
Adding Pyomo requirements to the base docker environment

### DIFF
--- a/linux_install_scripts/python_libs.sh
+++ b/linux_install_scripts/python_libs.sh
@@ -18,6 +18,9 @@ RUN bash -c 'pip list --format freeze | cut -d= -f1 | \
 RUN cat ${DYNAMIC_VARS_FILE} && echo ""
 
 ENV DOCKER_PYTHON_OPTIONAL \
+      appdirs \
+      ply \
+      six>=1.4 \
       sphinx \
       sphinx_rtd_theme \
       cffi \
@@ -45,6 +48,14 @@ ENV DOCKER_PYTHON_NOT_PYPY \
     seaborn
 RUN (python -c "import __pypy__" 2> /dev/null) \
     || (pip install ${DOCKER_PYTHON_NOT_PYPY})
+
+# These are extra packages required for Python 2.7
+ENV DOCKER_PYTHON2_ADDITIONAL \
+    argparse \
+    unittest2 \
+    ordereddict
+RUN (python -c "import sys; assert sys.version_info[0]==2" 2> /dev/null) \
+    && (pip install ${DOCKER_PYTHON2_ADDITIONAL}
 
 # These are fragile and may not work on PyPy / Python3.7
 RUN pip install PyYAML || \

--- a/linux_install_scripts/python_libs.sh
+++ b/linux_install_scripts/python_libs.sh
@@ -54,8 +54,8 @@ ENV DOCKER_PYTHON2_ADDITIONAL \
     argparse \
     unittest2 \
     ordereddict
-RUN (python -c "import sys; assert sys.version_info[0]==2" 2> /dev/null) \
-    && (pip install ${DOCKER_PYTHON2_ADDITIONAL}
+RUN (python -c "import sys; assert sys.version_info[0]>2" 2> /dev/null) \
+    || (pip install ${DOCKER_PYTHON2_ADDITIONAL}) 
 
 # These are fragile and may not work on PyPy / Python3.7
 RUN pip install PyYAML || \


### PR DESCRIPTION
This adds the base Pyomo dependencies to the Docker image.  Note that (intentionally) the SLIM build(s) will not contain these dependencies in order to test the Pyomo requirements (in setup.py).