### PR TITLE
Add the pathos library

### DIFF
--- a/linux_install_scripts/mipcl.sh
+++ b/linux_install_scripts/mipcl.sh
@@ -3,12 +3,12 @@ RUN echo "" && \
     echo "INSTALLING MIPCL" && \
     echo "================" && \
     echo ""
-ENV MIPCL_VERSION="2.2.0"
+ENV MIPCL_VERSION="2.5.4"
 ARG TARGET="mipcl-${MIPCL_VERSION}"
 ENV PATH="${PREFIX}/${TARGET}/bin:${PATH}"
 RUN cd ${PREFIX} && \
     rm -rf ${TARGET}.linux-x86_64.tar.gz && \
-    wget -q "http://www.mipcl-cpp.appspot.com/static/download/${TARGET}.linux-x86_64.tar.gz" && \
+    wget -q "http://www.mipcl-cpp.appspot.com/${TARGET}.linux-x86_64.tar.gz" && \
     tar xf ${TARGET}.linux-x86_64.tar.gz && \
     rm -rf ${TARGET}.linux-x86_64.tar.gz
 ARG TARGET

--- a/linux_install_scripts/mipcl.sh
+++ b/linux_install_scripts/mipcl.sh
@@ -8,7 +8,7 @@ ARG TARGET="mipcl-${MIPCL_VERSION}"
 ENV PATH="${PREFIX}/${TARGET}/bin:${PATH}"
 RUN cd ${PREFIX} && \
     rm -rf ${TARGET}.linux-x86_64.tar.gz && \
-    wget -q "http://www.mipcl-cpp.appspot.com/${TARGET}.linux-x86_64.tar.gz" && \
+    wget -q "http://www.mipcl-cpp.appspot.com/static/download/${TARGET}.linux-x86_64.tar.gz" && \
     tar xf ${TARGET}.linux-x86_64.tar.gz && \
     rm -rf ${TARGET}.linux-x86_64.tar.gz
 ARG TARGET

--- a/linux_install_scripts/python_libs.sh
+++ b/linux_install_scripts/python_libs.sh
@@ -29,6 +29,7 @@ ENV DOCKER_PYTHON_OPTIONAL \
     networkx \
     numpy \
     openpyxl \
+    pathos \
     pint \
     pymysql \
     Pyro4 \


### PR DESCRIPTION
This adds the `pathos` library to the docker container.  This partially fixes Pyomo/pyomo#1122.

In addition, this updates the MIPCL library to the currently available release.