### PR TITLE
Adding cmake to the docker image

### DIFF
--- a/linux_install_scripts/libs.sh
+++ b/linux_install_scripts/libs.sh
@@ -8,7 +8,7 @@ RUN dpkg --add-architecture i386 && \
     apt-get -q -y --no-install-recommends install \
         build-essential libssl-dev libffi-dev \
         wget zip unzip \
-        git subversion \
+        git subversion cmake \
         gfortran \
         libopenblas-dev \
         openmpi-bin openmpi-common libopenmpi-dev \


### PR DESCRIPTION
Trivial change to add cmake to the docker image (needed to build pynumero libraries).