### PR TITLE
Add Xpress to 'non-pypy' Python versions

### DIFF
--- a/linux_install_scripts/python_libs.sh
+++ b/linux_install_scripts/python_libs.sh
@@ -47,6 +47,7 @@ ENV DOCKER_PYTHON_NOT_PYPY \
     scipy \
     matplotlib \
     pandas \
+    xpress \
     seaborn
 RUN (python -c "import __pypy__" 2> /dev/null) \
     || (pip install ${DOCKER_PYTHON_NOT_PYPY})


### PR DESCRIPTION
[Pyomo Issue #1444](https://github.com/Pyomo/pyomo/issues/1444)

This addresses the above issue and adds Xpress to the Travis testing suite. 