### PR TITLE
Adding python-louvain to testing infrastructure, as per issue 1626

### DIFF
--- a/create_linux_dockerfile.py
+++ b/create_linux_dockerfile.py
@@ -8,6 +8,7 @@ CMD ["/bin/bash"]
 """
 
 installs = ['linux_install_scripts/libs.sh',
+            'linux_install_scripts/make_unsafe_wget.sh',
             'linux_install_scripts/python_libs.sh',
             'linux_install_scripts/baron.sh',
 #            'linux_install_scripts/mipcl.sh',
@@ -17,8 +18,8 @@ installs = ['linux_install_scripts/libs.sh',
             'linux_install_scripts/gams.sh',
             'linux_install_scripts/glpk.sh',
             'linux_install_scripts/ipopt.sh',
-            'linux_install_scripts/cbc.sh'
-            ]
+            'linux_install_scripts/cbc.sh',
+            'linux_install_scripts/restore_standard_wget.sh']
 dynamic_vars_filename = '/root/dynamic_vars.out'
 
 def create_dockerfile(source_image, python_exe, dirname):

--- a/linux_install_scripts/gsl.sh
+++ b/linux_install_scripts/gsl.sh
@@ -6,7 +6,7 @@ RUN echo "" && \
 ARG TARGET="amplgsl.linux-intel64"
 RUN cd ${PREFIX} && \
     rm -rf ${TARGET}.zip && \
-    wget -q "https://www.ampl.com/NEW/amplgsl/${TARGET}.zip" && \
+    wget -q --no-check-certificate "https://www.ampl.com/NEW/amplgsl/${TARGET}.zip" && \
     mkdir Gsl && \
     unzip -q -d Gsl ${TARGET}.zip && \
     cd Gsl && \

--- a/linux_install_scripts/gsl.sh
+++ b/linux_install_scripts/gsl.sh
@@ -6,7 +6,7 @@ RUN echo "" && \
 ARG TARGET="amplgsl.linux-intel64"
 RUN cd ${PREFIX} && \
     rm -rf ${TARGET}.zip && \
-    wget -q --no-check-certificate "https://www.ampl.com/NEW/amplgsl/${TARGET}.zip" && \
+    wget -q "https://www.ampl.com/NEW/amplgsl/${TARGET}.zip" && \
     mkdir Gsl && \
     unzip -q -d Gsl ${TARGET}.zip && \
     cd Gsl && \

--- a/linux_install_scripts/make_unsafe_wget.sh
+++ b/linux_install_scripts/make_unsafe_wget.sh
@@ -1,0 +1,10 @@
+RUN echo "" && \
+    echo "===============" && \
+    echo "OVERRIDING WGET" && \
+    echo "===============" && \
+    echo ""
+RUN mv /usr/bin/wget /usr/bin/_wget && \
+    echo '#! /bin/bash\n\
+_wget --no-check-certificate $@\n\
+' > /usr/bin/wget && \
+    chmod a+x /usr/bin/wget

--- a/linux_install_scripts/python_libs.sh
+++ b/linux_install_scripts/python_libs.sh
@@ -35,6 +35,7 @@ ENV DOCKER_PYTHON_OPTIONAL \
     Pyro4 \
     pytest \
     pytest-qt \
+    python-louvain \
     sphinx \
     sphinx_rtd_theme \
     sympy \

--- a/linux_install_scripts/restore_standard_wget.sh
+++ b/linux_install_scripts/restore_standard_wget.sh
@@ -1,0 +1,6 @@
+RUN echo "" && \
+    echo "==============" && \
+    echo "RESTORING WGET" && \
+    echo "==============" && \
+    echo ""
+RUN mv /usr/bin/_wget /usr/bin/wget


### PR DESCRIPTION
As requested, this change adds the library `python-louvain` to the testing infrastructure to satisfy https://github.com/Pyomo/pyomo/issues/1626.